### PR TITLE
Google sign-in using `id_token` parameter

### DIFF
--- a/hasura-auth/src/main/java/io/hasura/auth/AuthService.java
+++ b/hasura-auth/src/main/java/io/hasura/auth/AuthService.java
@@ -191,9 +191,7 @@ public class AuthService {
     }
 
     public Call<SocialLoginResponse, AuthException> socialAuth(SocialLoginRequest r) {
-        String provider = r.provider;
-        String accessToken = r.accessToken;
-        String url = "/auth/social/" + provider + "/authenticate?access_token=" + accessToken;
+        String url = r.prepareRequestURL();
         Type respType = new TypeToken<SocialLoginResponse>() {
         }.getType();
         return mkGetCall(url, respType);

--- a/hasura-auth/src/main/java/io/hasura/auth/SocialLoginRequest.java
+++ b/hasura-auth/src/main/java/io/hasura/auth/SocialLoginRequest.java
@@ -6,10 +6,16 @@ import com.google.gson.annotations.SerializedName;
 public class SocialLoginRequest {
     String provider;
     String accessToken;
+    String idToken;
 
     public SocialLoginRequest(String provider, String token) {
         this.provider = provider;
-        this.accessToken = token;
+        if(provider == "google") {
+          this.idToken = token;
+        }
+        else {
+          this.accessToken = token;
+        }
     }
 
     public void setProvider(String provider) {
@@ -18,5 +24,14 @@ public class SocialLoginRequest {
 
     public void setAccessToken(String token) {
         this.accessToken = token;
+    }
+
+    public String prepareRequestURL() {
+        if(idToken != null) {
+          return "/auth/social/" + provider + "/authenticate?id_token=" + idToken;
+        }
+        else {
+          return "/auth/social/" + provider + "/authenticate?access_token=" + accessToken;
+        }
     }
 }


### PR DESCRIPTION
Just initilize SocialLoginRequest as you would previously. If the provider is set to "google", everything will be taken care behind the scenes.